### PR TITLE
Infer Encoded DB Matrix Element Bit Length Automatically

### DIFF
--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -27,6 +27,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Increase Rust Compiler stack size
+        run: echo "RUST_MIN_STACK=67108864" >> $GITHUB_ENV
 
       - name: Build and Test on ${{ matrix.os }}
         run: cargo test --profile test-release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ categories = ["cryptography", "data-structures"]
 
 [dependencies]
 sha3 = "=0.10.8"
-rand = "=0.8.5"
-rand_chacha = "=0.3.1"
+rand = "=0.9.0"
+rand_chacha = "=0.9.0"
 serde = { version = "=1.0.217", features = ["derive"] }
 bincode = "=1.3.3"
 rayon = "=1.10.0"

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ fn main() {
     let mut seed_μ = [0u8; 32]; // You'll want to generate a cryptographically secure random seed
     rng.fill_bytes(&mut seed_μ);
 
-    let (server, hint_bytes, filter_param_bytes) = Server::setup::<3>(10, &seed_μ, db.clone()).expect("Server setup failed");
+    let (server, hint_bytes, filter_param_bytes) = Server::setup::<3>(&seed_μ, db.clone()).expect("Server setup failed");
 
     // Client setup (offline phase)
     let mut client = Client::setup(&seed_μ, &hint_bytes, &filter_param_bytes).expect("Client setup failed");
@@ -154,7 +154,7 @@ fn main() {
 }
 ```
 
-The constant parameter `ARITY` (3 or 4) in `Server::setup` controls the type of Binary Fuse Filter used,which affects size of the query vector and the encoded database dimensions, stored in-memory server-side. Also, the `mat_elem_bit_len` parameter impacts the correctness and performance of the PIR scheme. It depends on the number of entries in the database. I advise you to see eq. 8 in section 5.1 of FrodoPIR paper @ https://ia.cr/2022/981. For suggested values of `mat_elem_bit_len` for different database sizes, I advise you to have a look at table 5 in section 5.2 of FrodoPIR paper. Interpret $ρ = 2^{mat\_elem\_bit\_len}$.
+The constant parameter `ARITY` (3 or 4) in `Server::setup` controls the type of Binary Fuse Filter used to encode the KV database, which affects size of the query vector and the encoded database dimensions, stored in-memory server-side. This implementation should allow you to run PIR queries on a KV database with at max 2^42 (~4 trillion) number of entries.
 
 I maintain one example [program](./examples/kw_pir.rs) which demonstrates usage of the ChalametPIR API.
 
@@ -169,7 +169,6 @@ Number of entries in Key-Value Database   : 65536
 Size of each key                          : 8.0B
 Size of each value                        : 4.0B
 Arity of Binary Fuse Filter               : 3
-Encoded DB matrix element bit length      : 10
 Seed size                                 : 32.0B
 Hint size                                 : 207.9KB
 Filter parameters size                    : 68.0B
@@ -205,7 +204,6 @@ Number of entries in Key-Value Database   : 65536
 Size of each key                          : 8.0B
 Size of each value                        : 4.0B
 Arity of Binary Fuse Filter               : 4
-Encoded DB matrix element bit length      : 10
 Seed size                                 : 32.0B
 Hint size                                 : 207.9KB
 Filter parameters size                    : 68.0B

--- a/benches/offline_phase.rs
+++ b/benches/offline_phase.rs
@@ -55,7 +55,7 @@ const ARITIES: [u32; 2] = [3, 4];
 
 #[divan::bench(args = ARGS, consts = ARITIES, max_time = Duration::from_secs(300), skip_ext_time = true)]
 fn server_setup<const ARITY: u32>(bencher: divan::Bencher, db_config: &DBConfig) {
-    let mut rng = ChaCha8Rng::from_entropy();
+    let mut rng = ChaCha8Rng::from_os_rng();
 
     let kv = generate_random_kv_database(&mut rng, db_config.db_entry_count, db_config.key_byte_len, db_config.value_byte_len);
     let kv_as_ref = kv.iter().map(|(k, v)| (k.as_slice(), v.as_slice())).collect::<HashMap<&[u8], &[u8]>>();
@@ -70,7 +70,7 @@ fn server_setup<const ARITY: u32>(bencher: divan::Bencher, db_config: &DBConfig)
 
 #[divan::bench(args = ARGS, consts = ARITIES, max_time = Duration::from_secs(300), skip_ext_time = true)]
 fn client_setup<const ARITY: u32>(bencher: divan::Bencher, db_config: &DBConfig) {
-    let mut rng = ChaCha8Rng::from_entropy();
+    let mut rng = ChaCha8Rng::from_os_rng();
 
     let kv = generate_random_kv_database(&mut rng, db_config.db_entry_count, db_config.key_byte_len, db_config.value_byte_len);
     let kv_as_ref = kv.iter().map(|(k, v)| (k.as_slice(), v.as_slice())).collect::<HashMap<&[u8], &[u8]>>();

--- a/benches/online_phase.rs
+++ b/benches/online_phase.rs
@@ -55,7 +55,7 @@ const ARITIES: [u32; 2] = [3, 4];
 
 #[divan::bench(args = ARGS, consts = ARITIES, max_time = Duration::from_secs(300), skip_ext_time = true)]
 fn client_query<const ARITY: u32>(bencher: divan::Bencher, db_config: &DBConfig) {
-    let mut rng = ChaCha8Rng::from_entropy();
+    let mut rng = ChaCha8Rng::from_os_rng();
 
     let kv = generate_random_kv_database(&mut rng, db_config.db_entry_count, db_config.key_byte_len, db_config.value_byte_len);
     let kv_as_ref = kv.iter().map(|(k, v)| (k.as_slice(), v.as_slice())).collect::<HashMap<&[u8], &[u8]>>();
@@ -76,7 +76,7 @@ fn client_query<const ARITY: u32>(bencher: divan::Bencher, db_config: &DBConfig)
 
 #[divan::bench(args = ARGS, consts = ARITIES, max_time = Duration::from_secs(300), skip_ext_time = true)]
 fn server_respond<const ARITY: u32>(bencher: divan::Bencher, db_config: &DBConfig) {
-    let mut rng = ChaCha8Rng::from_entropy();
+    let mut rng = ChaCha8Rng::from_os_rng();
 
     let kv = generate_random_kv_database(&mut rng, db_config.db_entry_count, db_config.key_byte_len, db_config.value_byte_len);
     let kv_as_ref = kv.iter().map(|(k, v)| (k.as_slice(), v.as_slice())).collect::<HashMap<&[u8], &[u8]>>();
@@ -95,7 +95,7 @@ fn server_respond<const ARITY: u32>(bencher: divan::Bencher, db_config: &DBConfi
 
 #[divan::bench(args = ARGS, consts = ARITIES, max_time = Duration::from_secs(300), skip_ext_time = true)]
 fn client_process_response<const ARITY: u32>(bencher: divan::Bencher, db_config: &DBConfig) {
-    let mut rng = ChaCha8Rng::from_entropy();
+    let mut rng = ChaCha8Rng::from_os_rng();
 
     let kv = generate_random_kv_database(&mut rng, db_config.db_entry_count, db_config.key_byte_len, db_config.value_byte_len);
     let kv_as_ref = kv.iter().map(|(k, v)| (k.as_slice(), v.as_slice())).collect::<HashMap<&[u8], &[u8]>>();

--- a/benches/online_phase.rs
+++ b/benches/online_phase.rs
@@ -30,7 +30,6 @@ fn generate_random_kv_database(rng: &mut ChaCha8Rng, num_kv_pairs: usize, key_by
 #[derive(Debug)]
 struct DBConfig {
     db_entry_count: usize,
-    mat_elem_bit_len: usize,
     key_byte_len: usize,
     value_byte_len: usize,
 }
@@ -38,19 +37,16 @@ struct DBConfig {
 const ARGS: &[DBConfig] = &[
     DBConfig {
         db_entry_count: 1usize << 16,
-        mat_elem_bit_len: 10,
         key_byte_len: 32,
         value_byte_len: 1024,
     },
     DBConfig {
         db_entry_count: 1usize << 18,
-        mat_elem_bit_len: 10,
         key_byte_len: 32,
         value_byte_len: 1024,
     },
     DBConfig {
         db_entry_count: 1usize << 20,
-        mat_elem_bit_len: 9,
         key_byte_len: 32,
         value_byte_len: 1024,
     },
@@ -67,7 +63,7 @@ fn client_query<const ARITY: u32>(bencher: divan::Bencher, db_config: &DBConfig)
     let mut seed_μ = [0u8; server::SEED_BYTE_LEN];
     rng.fill_bytes(&mut seed_μ);
 
-    let (_, hint_bytes, filter_param_bytes) = server::Server::setup::<ARITY>(db_config.mat_elem_bit_len, &seed_μ, kv_as_ref.clone()).unwrap();
+    let (_, hint_bytes, filter_param_bytes) = server::Server::setup::<ARITY>(&seed_μ, kv_as_ref.clone()).unwrap();
     let client = client::Client::setup(&seed_μ, &hint_bytes, &filter_param_bytes).unwrap();
 
     let (&key, _) = kv_as_ref.iter().last().unwrap();
@@ -88,7 +84,7 @@ fn server_respond<const ARITY: u32>(bencher: divan::Bencher, db_config: &DBConfi
     let mut seed_μ = [0u8; server::SEED_BYTE_LEN];
     rng.fill_bytes(&mut seed_μ);
 
-    let (server, hint_bytes, filter_param_bytes) = server::Server::setup::<ARITY>(db_config.mat_elem_bit_len, &seed_μ, kv_as_ref.clone()).unwrap();
+    let (server, hint_bytes, filter_param_bytes) = server::Server::setup::<ARITY>(&seed_μ, kv_as_ref.clone()).unwrap();
     let mut client = client::Client::setup(&seed_μ, &hint_bytes, &filter_param_bytes).unwrap();
 
     let (&key, _) = kv_as_ref.iter().last().unwrap();
@@ -107,7 +103,7 @@ fn client_process_response<const ARITY: u32>(bencher: divan::Bencher, db_config:
     let mut seed_μ = [0u8; server::SEED_BYTE_LEN];
     rng.fill_bytes(&mut seed_μ);
 
-    let (server, hint_bytes, filter_param_bytes) = server::Server::setup::<ARITY>(db_config.mat_elem_bit_len, &seed_μ, kv_as_ref.clone()).unwrap();
+    let (server, hint_bytes, filter_param_bytes) = server::Server::setup::<ARITY>(&seed_μ, kv_as_ref.clone()).unwrap();
     let mut client = client::Client::setup(&seed_μ, &hint_bytes, &filter_param_bytes).unwrap();
 
     let (&key, _) = kv_as_ref.iter().last().unwrap();

--- a/examples/kw_pir.rs
+++ b/examples/kw_pir.rs
@@ -57,7 +57,7 @@ fn format_bytes(bytes: usize) -> String {
 fn main() {
     const ARITY: u32 = 3;
 
-    let mut rng = ChaCha8Rng::from_entropy();
+    let mut rng = ChaCha8Rng::from_os_rng();
 
     // Make a sample Key-Value database.
     let kv_db = make_toy_kv_db(&mut rng);
@@ -99,7 +99,7 @@ fn main() {
     let total_num_keys_to_be_queried = 20;
     let mut num_keys_quried = 0;
     while num_keys_quried < total_num_keys_to_be_queried {
-        let random_key = rng.gen_range(0..kv_db.len() * 2);
+        let random_key = rng.random_range(0..kv_db.len() * 2);
         let is_random_key_in_db = kv_db.contains_key(&random_key);
 
         let key_as_bytes = random_key.to_le_bytes();

--- a/examples/kw_pir.rs
+++ b/examples/kw_pir.rs
@@ -55,7 +55,6 @@ fn format_bytes(bytes: usize) -> String {
 }
 
 fn main() {
-    const MAT_ELEM_BIT_LEN: usize = 10;
     const ARITY: u32 = 3;
 
     let mut rng = ChaCha8Rng::from_entropy();
@@ -79,14 +78,13 @@ fn main() {
     println!("Size of each key                          : {}", format_bytes(key_byte_len));
     println!("Size of each value                        : {}", format_bytes(value_byte_len));
     println!("Arity of Binary Fuse Filter               : {}", ARITY);
-    println!("Encoded DB matrix element bit length      : {}", MAT_ELEM_BIT_LEN);
 
     // Sample seed for producing public LWE matrix A.
     let mut seed_μ = [0u8; server::SEED_BYTE_LEN];
     rng.fill_bytes(&mut seed_μ);
 
     // Setup PIR server, for given KV database.
-    let (server_handle, hint_bytes, filter_param_bytes) = Server::setup::<ARITY>(MAT_ELEM_BIT_LEN, &seed_μ, kv_db_as_ref.clone()).expect("Server setup failed");
+    let (server_handle, hint_bytes, filter_param_bytes) = Server::setup::<ARITY>(&seed_μ, kv_db_as_ref.clone()).expect("Server setup failed");
 
     println!("Seed size                                 : {}", format_bytes(seed_μ.len()));
     println!("Hint size                                 : {}", format_bytes(hint_bytes.len()));

--- a/src/pir_internals/binary_fuse_filter.rs
+++ b/src/pir_internals/binary_fuse_filter.rs
@@ -88,7 +88,7 @@ impl BinaryFuseFilter {
         let mut ultimate_size = 0;
 
         let mut seed = [0u8; 32];
-        let mut rng = ChaCha20Rng::from_entropy();
+        let mut rng = ChaCha20Rng::from_os_rng();
 
         for _ in 0..max_attempt_count {
             rng.fill_bytes(&mut seed);
@@ -296,7 +296,7 @@ impl BinaryFuseFilter {
         let mut ultimate_size = 0;
 
         let mut seed = [0u8; 32];
-        let mut rng = ChaCha20Rng::from_entropy();
+        let mut rng = ChaCha20Rng::from_os_rng();
 
         for _ in 0..max_attempt_count {
             rng.fill_bytes(&mut seed);

--- a/src/pir_internals/matrix.rs
+++ b/src/pir_internals/matrix.rs
@@ -227,7 +227,7 @@ impl Matrix {
         const TERNARY_INTERVAL_SIZE: u32 = (u32::MAX - 2) / 3;
         const TERNARY_REJECTION_SAMPLING_MAX: u32 = TERNARY_INTERVAL_SIZE * 3;
 
-        let mut rng = ChaCha8Rng::from_entropy();
+        let mut rng = ChaCha8Rng::from_os_rng();
         let mut vec = Matrix::new(rows, cols)?;
 
         let num_elems = rows * cols;
@@ -237,7 +237,7 @@ impl Matrix {
             let mut val = u32::MAX;
 
             while branch_opt_util::unlikely(val > TERNARY_REJECTION_SAMPLING_MAX) {
-                val = rng.gen::<u32>();
+                val = rng.random::<u32>();
             }
 
             let ternary = if val <= TERNARY_INTERVAL_SIZE {
@@ -729,11 +729,11 @@ pub mod test {
         const MAX_VALUE_BYTE_LEN: usize = 512;
 
         let mut kv = HashMap::with_capacity(num_kv_pairs);
-        let mut rng = ChaCha8Rng::from_entropy();
+        let mut rng = ChaCha8Rng::from_os_rng();
 
         for _ in 0..num_kv_pairs {
-            let key_byte_len = rng.gen_range(MIN_KEY_BYTE_LEN..=MAX_KEY_BYTE_LEN);
-            let value_byte_len = rng.gen_range(MIN_VALUE_BYTE_LEN..=MAX_VALUE_BYTE_LEN);
+            let key_byte_len = rng.random_range(MIN_KEY_BYTE_LEN..=MAX_KEY_BYTE_LEN);
+            let value_byte_len = rng.random_range(MIN_VALUE_BYTE_LEN..=MAX_VALUE_BYTE_LEN);
 
             let mut key = vec![0u8; key_byte_len];
             let mut value = vec![0u8; value_byte_len];
@@ -823,15 +823,15 @@ pub mod test {
         const MIN_MATRIX_DIM: usize = 1;
         const MAX_MATRIX_DIM: usize = 1024;
 
-        let mut rng = ChaCha8Rng::from_entropy();
+        let mut rng = ChaCha8Rng::from_os_rng();
 
         let mut seed = [0u8; SEED_BYTE_LEN];
         rng.fill_bytes(&mut seed);
 
         let mut current_attempt_count = 0;
         while current_attempt_count < NUM_ATTEMPT_MATRIX_MULTIPLICATIONS {
-            let num_rows = rng.gen_range(MIN_MATRIX_DIM..=MAX_MATRIX_DIM);
-            let num_cols = rng.gen_range(MIN_MATRIX_DIM..=MAX_MATRIX_DIM);
+            let num_rows = rng.random_range(MIN_MATRIX_DIM..=MAX_MATRIX_DIM);
+            let num_cols = rng.random_range(MIN_MATRIX_DIM..=MAX_MATRIX_DIM);
 
             let matrix_a = Matrix::generate_from_seed(num_rows, num_cols, &seed).expect("Matrix must be generated from seed");
             let matrix_i = Matrix::identity(num_cols).expect("Identity matrix must be created");
@@ -852,7 +852,7 @@ pub mod test {
         const NUM_ROWS_IN_MATRIX: usize = 1024;
         const NUM_COLS_IN_MATRIX: usize = NUM_ROWS_IN_MATRIX + 1;
 
-        let mut rng = ChaCha8Rng::from_entropy();
+        let mut rng = ChaCha8Rng::from_os_rng();
 
         let mut seed = [0u8; SEED_BYTE_LEN];
         rng.fill_bytes(&mut seed);
@@ -871,7 +871,7 @@ pub mod test {
         const NUM_ROWS_IN_MATRIX: usize = 1024;
         const NUM_COLS_IN_MATRIX: usize = NUM_ROWS_IN_MATRIX + 1;
 
-        let mut rng = ChaCha8Rng::from_entropy();
+        let mut rng = ChaCha8Rng::from_os_rng();
 
         let mut seed = [0u8; SEED_BYTE_LEN];
         rng.fill_bytes(&mut seed);

--- a/src/pir_internals/serialization.rs
+++ b/src/pir_internals/serialization.rs
@@ -243,7 +243,7 @@ mod test {
         const MIN_MAT_ELEM_BIT_LEN: usize = 7;
         const MAX_MAT_ELEM_BIT_LEN: usize = 11;
 
-        let mut rng = ChaCha8Rng::from_entropy();
+        let mut rng = ChaCha8Rng::from_os_rng();
 
         for key_byte_len in MIN_KEY_BYTE_LEN..=MAX_KEY_BYTE_LEN {
             for value_byte_len in MIN_VALUE_BYTE_LEN..=MAX_VALUE_BYTE_LEN {

--- a/src/test_pir.rs
+++ b/src/test_pir.rs
@@ -14,7 +14,7 @@ fn test_keyword_pir_with_3_wise_xor_filter() {
     let kv_db = generate_random_kv_database(NUM_KV_PAIRS);
     let kv_db_as_ref = kv_db.iter().map(|(k, v)| (k.as_slice(), v.as_slice())).collect::<HashMap<&[u8], &[u8]>>();
 
-    let mut rng = ChaCha8Rng::from_entropy();
+    let mut rng = ChaCha8Rng::from_os_rng();
 
     let mut seed_μ = [0u8; 32];
     rng.fill_bytes(&mut seed_μ);
@@ -64,7 +64,7 @@ fn test_keyword_pir_with_4_wise_xor_filter() {
     let kv_db = generate_random_kv_database(NUM_KV_PAIRS);
     let kv_db_as_ref = kv_db.iter().map(|(k, v)| (k.as_slice(), v.as_slice())).collect::<HashMap<&[u8], &[u8]>>();
 
-    let mut rng = ChaCha8Rng::from_entropy();
+    let mut rng = ChaCha8Rng::from_os_rng();
 
     let mut seed_μ = [0u8; 32];
     rng.fill_bytes(&mut seed_μ);

--- a/src/test_pir.rs
+++ b/src/test_pir.rs
@@ -9,7 +9,6 @@ use std::collections::HashMap;
 #[test]
 fn test_keyword_pir_with_3_wise_xor_filter() {
     const NUM_KV_PAIRS: usize = 2usize.pow(12);
-    const MAT_ELEM_BIT_LEN: usize = 10;
     const ARITY: u32 = 3;
 
     let kv_db = generate_random_kv_database(NUM_KV_PAIRS);
@@ -20,7 +19,7 @@ fn test_keyword_pir_with_3_wise_xor_filter() {
     let mut seed_μ = [0u8; 32];
     rng.fill_bytes(&mut seed_μ);
 
-    let (server, hint_bytes, filter_param_bytes) = Server::setup::<ARITY>(MAT_ELEM_BIT_LEN, &seed_μ, kv_db_as_ref.clone()).expect("Server setup failed");
+    let (server, hint_bytes, filter_param_bytes) = Server::setup::<ARITY>(&seed_μ, kv_db_as_ref.clone()).expect("Server setup failed");
     let mut client = Client::setup(&seed_μ, &hint_bytes, &filter_param_bytes).expect("Client setup failed");
 
     let mut kv_iter = kv_db_as_ref.iter();
@@ -60,7 +59,6 @@ fn test_keyword_pir_with_3_wise_xor_filter() {
 #[test]
 fn test_keyword_pir_with_4_wise_xor_filter() {
     const NUM_KV_PAIRS: usize = 2usize.pow(12);
-    const MAT_ELEM_BIT_LEN: usize = 10;
     const ARITY: u32 = 4;
 
     let kv_db = generate_random_kv_database(NUM_KV_PAIRS);
@@ -71,7 +69,7 @@ fn test_keyword_pir_with_4_wise_xor_filter() {
     let mut seed_μ = [0u8; 32];
     rng.fill_bytes(&mut seed_μ);
 
-    let (server, hint_bytes, filter_param_bytes) = Server::setup::<ARITY>(MAT_ELEM_BIT_LEN, &seed_μ, kv_db_as_ref.clone()).expect("Server setup failed");
+    let (server, hint_bytes, filter_param_bytes) = Server::setup::<ARITY>(&seed_μ, kv_db_as_ref.clone()).expect("Server setup failed");
     let mut client = Client::setup(&seed_μ, &hint_bytes, &filter_param_bytes).expect("Client setup failed");
 
     let mut kv_iter = kv_db_as_ref.iter();


### PR DESCRIPTION
Compute best-fit encoded DB matrix element bit-length, do not expect user to set it anymore.
