### PR TITLE
Do not use `serde` and `bincode` crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,16 +14,14 @@ categories = ["cryptography", "data-structures"]
 
 [dependencies]
 turboshake = "=0.4.1"
+rayon = "=1.10.0"
 rand = "=0.9.0"
 rand_chacha = "=0.9.0"
-serde = { version = "=1.0.218", features = ["derive"] }
-bincode = "=1.3.3"
-rayon = "=1.10.0"
 
 [dev-dependencies]
+test-case = "=3.3.1"
 divan = "=0.1.17"
 unicode-xid = "=0.2.6"
-test-case = "=3.3.1"
 
 [[bench]]
 name = "offline_phase"

--- a/src/client.rs
+++ b/src/client.rs
@@ -135,7 +135,7 @@ impl Client {
             query_vec_b[(0, h2 as usize)] = added_val;
         }
 
-        let query_bytes = query_vec_b.to_bytes()?;
+        let query_bytes = query_vec_b.to_bytes();
         self.pending_queries.insert(key.to_vec(), Query { vec_c: secret_vec_c });
 
         Ok(query_bytes)
@@ -189,7 +189,7 @@ impl Client {
             query_vec_b[(0, h3 as usize)] = added_val;
         }
 
-        let query_bytes = query_vec_b.to_bytes()?;
+        let query_bytes = query_vec_b.to_bytes();
         self.pending_queries.insert(key.to_vec(), Query { vec_c: secret_vec_c });
 
         Ok(query_bytes)

--- a/src/pir_internals/binary_fuse_filter.rs
+++ b/src/pir_internals/binary_fuse_filter.rs
@@ -454,24 +454,13 @@ impl BinaryFuseFilter {
 
         unsafe {
             bytes.get_unchecked_mut(offset0..offset1).copy_from_slice(&self.seed);
-            bytes
-                .get_unchecked_mut(offset1..offset2)
-                .copy_from_slice(&std::mem::transmute::<u32, [u8; std::mem::size_of::<u32>()]>(self.arity));
-            bytes
-                .get_unchecked_mut(offset2..offset3)
-                .copy_from_slice(&std::mem::transmute::<u32, [u8; std::mem::size_of::<u32>()]>(self.segment_length));
-            bytes
-                .get_unchecked_mut(offset3..offset4)
-                .copy_from_slice(&std::mem::transmute::<u32, [u8; std::mem::size_of::<u32>()]>(self.segment_count_length));
-            bytes
-                .get_unchecked_mut(offset4..offset5)
-                .copy_from_slice(&std::mem::transmute::<usize, [u8; std::mem::size_of::<usize>()]>(self.num_fingerprints));
-            bytes
-                .get_unchecked_mut(offset5..offset6)
-                .copy_from_slice(&std::mem::transmute::<usize, [u8; std::mem::size_of::<usize>()]>(self.filter_size));
-            bytes
-                .get_unchecked_mut(offset6..)
-                .copy_from_slice(&std::mem::transmute::<usize, [u8; std::mem::size_of::<usize>()]>(self.mat_elem_bit_len));
+            bytes.get_unchecked_mut(offset1..offset2).copy_from_slice(&self.arity.to_le_bytes());
+            bytes.get_unchecked_mut(offset2..offset3).copy_from_slice(&self.segment_length.to_le_bytes());
+            #[rustfmt::skip]
+            bytes.get_unchecked_mut(offset3..offset4).copy_from_slice(&self.segment_count_length.to_le_bytes());
+            bytes.get_unchecked_mut(offset4..offset5).copy_from_slice(&self.num_fingerprints.to_le_bytes());
+            bytes.get_unchecked_mut(offset5..offset6).copy_from_slice(&self.filter_size.to_le_bytes());
+            bytes.get_unchecked_mut(offset6..).copy_from_slice(&self.mat_elem_bit_len.to_le_bytes());
         }
 
         bytes

--- a/src/pir_internals/error.rs
+++ b/src/pir_internals/error.rs
@@ -13,8 +13,7 @@ pub enum ChalametPIRError {
     InvalidNumberOfElementsInMatrix,
     IncompatibleDimensionForRowVectorTransposedMatrixMultiplication,
     InvalidDimensionForVector,
-    FailedToSerializeMatrixToBytes(String),
-    FailedToDeserializeMatrixFromBytes(String),
+    FailedToDeserializeMatrixFromBytes,
 
     // Binary Fuse Filter
     EmptyKVDatabase,
@@ -22,8 +21,7 @@ pub enum ChalametPIRError {
     ExhaustedAllAttemptsToBuild4WiseXorFilter(usize),
     RowNotDecodable,
     DecodedRowNotPrependedWithDigestOfKey,
-    FailedToSerializeFilterToBytes(String),
-    FailedToDeserializeFilterFromBytes(String),
+    FailedToDeserializeFilterFromBytes,
 
     // PIR
     KVDatabaseSizeTooLarge,
@@ -46,8 +44,7 @@ impl Display for ChalametPIRError {
                 write!(f, "The dimensions are incompatible for multiplication of a row vector and a transposed matrix.")
             }
             Self::InvalidDimensionForVector => write!(f, "A vector must have either one row or one column."),
-            Self::FailedToSerializeMatrixToBytes(e) => write!(f, "Matrix serialization failed with: {}", e),
-            Self::FailedToDeserializeMatrixFromBytes(e) => write!(f, "Matrix deserialization failed with: {}", e),
+            Self::FailedToDeserializeMatrixFromBytes => write!(f, "Matrix deserialization failed"),
 
             Self::EmptyKVDatabase => write!(f, "Cannot encode empty key-value database."),
             Self::ExhaustedAllAttemptsToBuild3WiseXorFilter(max_num_attempts) => {
@@ -58,8 +55,7 @@ impl Display for ChalametPIRError {
             }
             Self::RowNotDecodable => write!(f, "Encoded KV database matrix's row cannot be decoded."),
             Self::DecodedRowNotPrependedWithDigestOfKey => write!(f, "Decoded row does not have the digest of the key prepended to it."),
-            Self::FailedToSerializeFilterToBytes(e) => write!(f, "Binary fuse filter serialization failed with: {}", e),
-            Self::FailedToDeserializeFilterFromBytes(e) => write!(f, "Binary fuse filter deserialization failed with: {}", e),
+            Self::FailedToDeserializeFilterFromBytes => write!(f, "Binary fuse filter deserialization failed"),
 
             Self::KVDatabaseSizeTooLarge => write!(f, "The key-value database is too large; it can have a maximum of 2^42 entries."),
             Self::InvalidHintMatrix => write!(f, "Unexpected number of rows in the hint matrix."),

--- a/src/pir_internals/matrix.rs
+++ b/src/pir_internals/matrix.rs
@@ -584,12 +584,8 @@ impl Matrix {
         let mut bytes = vec![0u8; total_byte_len];
 
         unsafe {
-            bytes
-                .get_unchecked_mut(offset0..offset1)
-                .copy_from_slice(&std::mem::transmute::<usize, [u8; std::mem::size_of::<usize>()]>(self.rows));
-            bytes
-                .get_unchecked_mut(offset1..offset2)
-                .copy_from_slice(&std::mem::transmute::<usize, [u8; std::mem::size_of::<usize>()]>(self.cols));
+            bytes.get_unchecked_mut(offset0..offset1).copy_from_slice(&self.rows.to_le_bytes());
+            bytes.get_unchecked_mut(offset1..offset2).copy_from_slice(&self.cols.to_le_bytes());
             bytes.get_unchecked_mut(offset2..).copy_from_slice(elems_as_bytes);
         }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -55,8 +55,8 @@ impl Server {
         let pub_mat_a = unsafe { Matrix::generate_from_seed(pub_mat_a_num_rows, pub_mat_a_num_cols, seed_μ).unwrap_unchecked() };
 
         let hint_mat_m = unsafe { (&pub_mat_a * &parsed_db_mat_d).unwrap_unchecked() };
-        let hint_bytes = hint_mat_m.to_bytes()?;
-        let filter_param_bytes: Vec<u8> = filter.to_bytes()?;
+        let hint_bytes = hint_mat_m.to_bytes();
+        let filter_param_bytes: Vec<u8> = filter.to_bytes();
         let transposed_parsed_db_mat_d = parsed_db_mat_d.transpose();
 
         Ok((Server { transposed_parsed_db_mat_d }, hint_bytes, filter_param_bytes))
@@ -81,7 +81,7 @@ impl Server {
         let query_vector = Matrix::from_bytes(query)?;
         let response_vector = query_vector.row_vector_x_transposed_matrix(&self.transposed_parsed_db_mat_d)?;
 
-        response_vector.to_bytes()
+        Ok(response_vector.to_bytes())
     }
 
     /// This is required to ensure that LWE PIR protocol is correct. See eq. 8 in section 5.1 of the FrodoPIR paper @ https://ia.cr/2022/981.


### PR DESCRIPTION
- [x] Remove `serde` and `bincode` crates as dependency of this project
- [x] Manually serialize and deserialize binary fuse filter and matrix struct
